### PR TITLE
Updated GitPython Version to 3.1.37

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.11.1
 lxml>=4.9.1
 requests==2.31.0
-GitPython==3.1.32
+GitPython==3.1.37
 PyGithub==1.59.1
 PyYAML==6.0.1


### PR DESCRIPTION
Updated as new for secrutiy patches are avialble in GitPython 3.1.37